### PR TITLE
Fix packaging

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,1 @@
 Django==1.11.5
--e git+https://github.com/uktrade/export-elements.git@v0.1.0#egg=export_elements

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
--e git+https://github.com/uktrade/export-elements.git@v0.1.0#egg=export_elements
 django==1.11.5
 pytz==2017.2              # via django

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements_test.txt requirements_test.in
 #
--e git+https://github.com/uktrade/export-elements.git@v0.1.0#egg=export_elements
 certifi==2017.4.17        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.9


### PR DESCRIPTION
When installing directory components the pip cannot find a package for the sub-dependency export-elements. Pip seems to have obtuse support for sub-dependencies that are urls (github links).

Workaround this by including export-elements dependency beside directory-components