### PR TITLE
Add django admin IP restrictor middleware helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Then visit the demo at `components.trade.great:9013`
 ### Environment variables
 
 | Environment variable | Notes |
-|----------------------|-------|
+|-------------------------------------------|-----------------------------------------------|
 | `FEATURE_SEARCH_ENGINE_INDEXING_DISABLED` | Controls `RobotsIndexControlHeaderMiddlware`. |
-| `FEATURE_MAINTENANCE_MODE_ENABLED` | Controls `MaintenanceModeMiddleware`. |
-| `FEATURE_FLAGS` | Place to store the service's feature flags. |
+| `FEATURE_MAINTENANCE_MODE_ENABLED`        | Controls `MaintenanceModeMiddleware`.         |
+| `FEATURE_FLAGS`                           | Place to store the service's feature flags.   |
+| `IP_RETRIEVER_NAME_GOV_UK`                | Method for determining client IP address: 'govuk-paas' or 'ipware'
 
 ### Middleware
 
@@ -53,9 +54,12 @@ Middleware can be found in `directory_components.middleware.FooBar`.
 | Middleware | Notes |
 |------------|-------|
 | `RobotsIndexControlHeaderMiddlware` | Informs the webcrawlers to not index the service if `FEATURE_SEARCH_ENGINE_INDEXING_DISABLED` is `true`. |
-| `MaintenanceModeMiddleware` | Redirects to http://sorry.great.gov.uk if `FEATURE_MAINTENANCE_MODE_ENABLED` is `true`.|
-| `NoCacheMiddlware` | Prevents any page in the service from caching pages of logged in users. |
-| `PrefixUrlMiddleware` | Redirects use from unprefixed url to prefixed url if `FEATURE_URL_PREFIX_ENABLED` is `true`. |
+| `MaintenanceModeMiddleware`         | Redirects to http://sorry.great.gov.uk if `FEATURE_MAINTENANCE_MODE_ENABLED` is `true`.|
+| `NoCacheMiddlware`                  | Prevents any page in the service from caching pages of logged in users. |
+| `PrefixUrlMiddleware`               | Redirects use from unprefixed url to prefixed url if `FEATURE_URL_PREFIX_ENABLED` is `true`. |
+| `IPRestrictorMiddleware`            | Convinience wrapper around (django-admin-ip-restrictor)[pypi.org/project/django-admin-ip-restrictor/]. |
+
+
 ### Context processors
 
 Middleware can be found in `directory_components.context_processors.foo_bar`.

--- a/directory_components/constants.py
+++ b/directory_components/constants.py
@@ -1,0 +1,3 @@
+# used by core.helpers.RemoteIPAddressRetriver
+IP_RETRIEVER_NAME_GOV_UK = 'govuk-paas'
+IP_RETRIEVER_NAME_IPWARE = 'ipware'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='2.32.0',
+    version='2.33.0',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',
@@ -16,6 +16,7 @@ setup(
         'django>=1.9,<2.0a1',
         'export_elements>=0.22.0<=1.0.0',
         'beautifulsoup4>=4.6.0<5.0.0',
+        'django-admin-ip-restrictor>=1.0.0,<2.0.0',
     ],
     extras_require={
         "test": [

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,23 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.views import View
+from django.views.generic.base import RedirectView
 
 import directory_components.views
 
 
+admin_urls = [
+    url(
+        r"^thing/$",
+        RedirectView.as_view(url='/login/'),
+        name='thing'
+    ),
+]
+
 urlpatterns = [
+    url(
+        r'^admin/',
+        include(admin_urls, namespace='admin', app_name='admin')
+    ),
     url(
         r"^robots\.txt$",
         directory_components.views.RobotsView.as_view(),


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/TT-768)

this wrapper around the django admin ip restrictor middleware handles the fact PaaS IP address is retrieved differently than on heroku. Stolen from directory-api