### PR TITLE
Make JS more selective when setting flag attributes

### DIFF
--- a/directory_components/static/directory_components/js/dit.components.countrySelector.js
+++ b/directory_components/static/directory_components/js/dit.components.countrySelector.js
@@ -97,7 +97,7 @@ dit.components.countrySelector = (new function() {
     $(COUNTRY_SELECT).on('change', function() {
       var country = '';
 
-      $("select option:selected").each(function() {
+      $(COUNTRY_SELECT).find("option:selected").each(function() {
         country = $(this).attr('value');
       });
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='7.2.0',
+    version='7.2.1',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
Previously if there was more than 1 select on a page the JS would always just select the final select on the page, which isn't always correct.