### PR TITLE
encode companies house search

### DIFF
--- a/directory_components/static/directory_components/js/dit.components.company-lookup.js
+++ b/directory_components/static/directory_components/js/dit.components.company-lookup.js
@@ -341,7 +341,7 @@ dit.components.lookup = (new function() {
     });
   }
   CompaniesHouseNameLookup.prototype.param = function() {
-    return "term=" + this._private.$input.val();
+    return "term=" + escape(this._private.$input.val());
   }
   CompaniesHouseNameLookup.prototype.setContent = function() {
     SelectiveLookup.prototype.setContent.call(this, {

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='8.4.0',
+    version='8.4.1',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
I tried encodeURI as recommended by docs. but it didn't work for me so I revered to escape. 

![image](https://user-images.githubusercontent.com/44236490/55424923-329c0400-5579-11e9-9cad-a036340be297.png)
