### PR TITLE
Add the GA 360 Tag Mixin to directory components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 10.6.0
+[Full Changelog](https://github.com/uktrade/directory-components/pull/179/files)
+
+**Implemented enhancements:**
+
+- [[CI-108]](https://uktrade.atlassian.net/browse/CI-108) Add mixin for Google Analytics Tags.
+
 ## 10.5.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/177/files)
 

--- a/directory_components/mixins.py
+++ b/directory_components/mixins.py
@@ -89,3 +89,14 @@ class CMSLanguageSwitcherMixin:
             *args,
             **kwargs
         )
+
+
+class GA360Mixin:
+    ga360_payload = None
+
+    def get_context_data(self, *args, **kwargs):
+        return super().get_context_data(
+            ga360=self.ga360_payload,
+            *args,
+            **kwargs
+        )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='10.5.0',
+    version='10.6.0',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -111,3 +111,15 @@ def test_cms_language_switcher_active_language_available(rf):
     context = response.context_data['language_switcher']
     assert context['show'] is True
     assert context['form'].initial['lang'] == 'de'
+
+
+def test_ga360_mixin(rf):
+    class TestView(mixins.GA360Mixin, TemplateView):
+        template_name = 'core/base.html'
+        ga360_payload = {'page_type': 'TestPageType'}
+
+    request = rf.get('/')
+    response = TestView.as_view()(request)
+
+    assert response.context_data['ga360']
+    assert response.context_data['ga360']['page_type'] == 'TestPageType'


### PR DESCRIPTION
This mixin already exists in Great Domestic.
We also need it now in Invest, and will also need it in other places (Great Internation and FAS)

I've therefore added this Mixin to Directory Components to aid sharing it between projects.