### PR TITLE
[CMS 1507] Add support for Django 2 -> 2.2

### DIFF
--- a/demo/config/settings.py
+++ b/demo/config/settings.py
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
     'directory_components',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'directory_components.middleware.LocaleQuerystringMiddleware',

--- a/directory_components/middleware.py
+++ b/directory_components/middleware.py
@@ -40,7 +40,7 @@ class NoCacheMiddlware(MiddlewareMixin):
         return response
 
 
-class AbstractPrefixUrlMiddleware(abc.ABC):
+class AbstractPrefixUrlMiddleware(abc.ABC, MiddlewareMixin):
 
     @property
     @abc.abstractmethod

--- a/directory_components/middleware.py
+++ b/directory_components/middleware.py
@@ -4,11 +4,12 @@ import urllib.parse
 
 import jsonschema as jsonschema
 from django.conf import settings
+from django.middleware.locale import LocaleMiddleware
 from django.shortcuts import redirect
 from django.utils import translation
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
-from django.middleware.locale import LocaleMiddleware
+from django.utils.deprecation import MiddlewareMixin
 from jsonschema import ValidationError
 
 from directory_components import constants
@@ -17,7 +18,7 @@ from directory_components import helpers
 logger = logging.getLogger(__name__)
 
 
-class MaintenanceModeMiddleware:
+class MaintenanceModeMiddleware(MiddlewareMixin):
     maintenance_url = 'https://sorry.great.gov.uk'
 
     def process_request(self, request):
@@ -25,7 +26,7 @@ class MaintenanceModeMiddleware:
             return redirect(self.maintenance_url)
 
 
-class NoCacheMiddlware:
+class NoCacheMiddlware(MiddlewareMixin):
     """Tell the browser to not cache the pages.
 
     Information that should be kept private can be viewed by anyone
@@ -84,7 +85,7 @@ def is_path_resolvable(path):
         return True
 
 
-class CountryMiddleware:
+class CountryMiddleware(MiddlewareMixin):
     def process_request(self, request):
         country_code = helpers.get_country_from_querystring(request)
         if country_code:
@@ -115,7 +116,7 @@ class LocaleQuerystringMiddleware(LocaleMiddleware):
             request.LANGUAGE_CODE = translation.get_language()
 
 
-class PersistLocaleMiddleware:
+class PersistLocaleMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if hasattr(settings, 'LANGUAGE_COOKIE_DEPRECATED_NAME'):
             response.delete_cookie(
@@ -131,7 +132,7 @@ class PersistLocaleMiddleware:
         return response
 
 
-class ForceDefaultLocale:
+class ForceDefaultLocale(MiddlewareMixin):
     """
     Force translation to English before view is called, then putting the user's
     original language back after the view has been called, laying the ground
@@ -176,7 +177,7 @@ ga_schema = {
 }
 
 
-class CheckGATags:
+class CheckGATags(MiddlewareMixin):
     def process_response(self, _, response):
 
         # Only check 2xx responses for google analytics.

--- a/directory_components/templatetags/directory_components.py
+++ b/directory_components/templatetags/directory_components.py
@@ -3,7 +3,15 @@ import re
 
 from django import template
 from django.templatetags import static
-from django.utils.text import slugify, mark_safe
+
+from django.utils.text import slugify
+try:
+    # Django < 2.2
+    from django.utils.test import mark_safe
+except ImportError:
+    # Django >= 2.2
+    from django.utils.html import mark_safe
+
 
 register = template.Library()
 

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'django>=2.0,<2.1a1',
         'beautifulsoup4>=4.6.0<5.0.0',
         'directory-constants>=17.0.0,<18.0.0',
         'jsonschema==3.0.1'
     ],
     extras_require={
         'test': [
+            'django>=2.0,<2.1a1',
             'ansicolors==1.1.8',
             'codecov==2.0.9',
             'flake8==3.0.4',
@@ -34,6 +34,7 @@ setup(
             'setuptools>=38.6.0,<39.0.0'
         ],
         'demo': [
+            'django>=2.0,<2.1a1',
             'django-environ==0.4.5',
             'gunicorn==19.5.0',
             'whitenoise==3.3.1',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'django>=1.11.20,<2.0a1',
+        'django>=2.0,<2.1a1',
         'beautifulsoup4>=4.6.0<5.0.0',
         'directory-constants>=17.0.0,<18.0.0',
         'jsonschema==3.0.1'
@@ -23,10 +23,10 @@ setup(
             'ansicolors==1.1.8',
             'codecov==2.0.9',
             'flake8==3.0.4',
-            'pytest-cov==2.3.1',
-            'pytest-django==3.0.0',
+            'pytest-cov==2.6.1',
+            'pytest-django==3.3.0',
             'pytest-sugar',
-            'pytest==3.0.3',
+            'pytest==3.6.0',
             'requests-toolbelt==0.8.0',
             'requests==2.18.1',
             'twine>=1.11.0,<2.0.0',
@@ -36,7 +36,7 @@ setup(
         'demo': [
             'django-environ==0.4.5',
             'gunicorn==19.5.0',
-            'whitenoise==3.1',
+            'whitenoise==3.3.1',
             'pip==9.0.1',
             'beautifulsoup4>=4.6.0,<5.0.0',
         ]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'django>=2.0,<2.1a1',
+            'django>=2.1,<2.2',
             'ansicolors==1.1.8',
             'codecov==2.0.9',
             'flake8==3.0.4',
@@ -34,7 +34,7 @@ setup(
             'setuptools>=38.6.0,<39.0.0'
         ],
         'demo': [
-            'django>=2.0,<2.1a1',
+            'django>=2.1,<2.2',
             'django-environ==0.4.5',
             'gunicorn==19.5.0',
             'whitenoise==3.3.1',

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,14 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
+        'django>=1.11,<3.0a1',
         'beautifulsoup4>=4.6.0<5.0.0',
         'directory-constants>=17.0.0,<18.0.0',
         'jsonschema==3.0.1'
     ],
     extras_require={
         'test': [
-            'django>=2.1,<2.2',
+            'django>=2.2,<3.0a1',
             'ansicolors==1.1.8',
             'codecov==2.0.9',
             'flake8==3.0.4',
@@ -34,7 +35,7 @@ setup(
             'setuptools>=38.6.0,<39.0.0'
         ],
         'demo': [
-            'django>=2.1,<2.2',
+            'django>=2.2,<3.0a1',
             'django-environ==0.4.5',
             'gunicorn==19.5.0',
             'whitenoise==3.3.1',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,8 @@ def pytest_configure():
             }
         },
         MIDDLEWARE_CLASSES=[
-            'directory_components.middleware.ForceDefaultLocale'],
+            'directory_components.middleware.ForceDefaultLocale'
+        ],
         SESSION_ENGINE='django.contrib.sessions.backends.cache',
         ROOT_URLCONF='tests.urls',
         SSO_PROXY_LOGIN_URL='http://login.com',

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -280,7 +280,7 @@ def test_locale_persist_middleware_deletes_deprecated_cookie(
     instance.process_response(request, response)
 
     cookie = response.cookies[settings.LANGUAGE_COOKIE_DEPRECATED_NAME]
-    assert cookie['expires'] == 'Thu, 01-Jan-1970 00:00:00 GMT'
+    assert cookie['expires'] == 'Thu, 01 Jan 1970 00:00:00 GMT'
     assert cookie['max-age'] == 0
 
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -19,10 +19,7 @@ urlpatterns = [
         View.as_view(),
         name='index',
     ),
-    url(
-        r'^admin/',
-        include(admin_urls, namespace='admin', app_name='admin')
-    ),
+    url(r'^admin/', include(admin_urls)),
     url(
         r"^robots\.txt$",
         directory_components.views.RobotsView.as_view(),


### PR DESCRIPTION
These changes should maintain compatibility with Django 1.11, whilst also supporting apps using Django versions up to 2.2.

There was a bit of a dependency-chain to follow (all demo and test requirements), and there were a couple of minor changes needed to keep the demo and test apps working.

The important changes here, in relation to compatibility with other apps, are:
- Middleware is now compatible with all supported Django versions, and can be used in the newer `MIDDLEWARE` setting, or the older `MIDDLEWARE_CLASSES` one.
- The included template tags should also be usable in all supported Django versions