### PR TITLE
Make component templates extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.1.0
+[Full Changelog](https://github.com/uktrade/directory-components/pull/225/files)
+
+### Implemented enhancements
+- Add overridable blocks to component templates to allow some services to modify them when needed
+
 ## 26.0.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/241/files)
 
@@ -15,7 +21,7 @@
 [Full Changelog](https://github.com/uktrade/directory-components/pull/240/file)
 
 ## Bugs fixed
-- Update lodash vulnerability 
+- Update lodash vulnerability
 
 ## 25.0.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/228/files)

--- a/directory_components/templates/directory_components/card.html
+++ b/directory_components/templates/directory_components/card.html
@@ -10,12 +10,15 @@
     href="{{ url }}"
     {% if card_id %}id="{{ card_id|add:'-link' }}"{% endif %}>
   {% endif %}
+    {% block image %}
     {% if img_src %}
       {% lazyload %}
         <img class="card-image" src="{{ img_src }}" alt="{{ img_alt }}" {% if card_id %}id="{{ card_id|add:'-image' }}"{% endif %}>
       {% endlazyload %}
     {% endif %}
+    {% endblock %}
     <div class="card-inner">
+      {% block content %}
       {% if html_content %}
       {{ html_content }}
       {% else %}
@@ -29,6 +32,7 @@
           <p class="description">{{ description }}</p>
         {% endif %}
       {% endif %}
+      {% endblock %}
     </div>
   {% if url %}
   </a>

--- a/directory_components/templates/directory_components/card_with_icon.html
+++ b/directory_components/templates/directory_components/card_with_icon.html
@@ -8,6 +8,7 @@
     {% if card_id %}id="{{ card_id|add:'-link' }}"{% endif %}>
   {% endif %}
     <div class="card-inner">
+      {% block content %}
       {% if img_src %}
         <img
           class="card-icon"
@@ -25,6 +26,7 @@
         <p class="description">{{ description }}</p>
         {% endif %}
       {% endif %}
+      {% endblock %}
     </div>
   {% if url %}
   </a>

--- a/directory_components/templates/directory_components/case_study.html
+++ b/directory_components/templates/directory_components/case_study.html
@@ -18,10 +18,12 @@
         {% lazyload %}
           <img class="only-display-tablet width-full margin-bottom-15" src="{% firstof background_image_url background_image img_url image_url image_src img_src image %}" alt="">
         {% endlazyload %}
+        {% block content %}
         <p>{% firstof subtitle description %}</p>
         {% if cta_link and cta_text %}
           <a class="button button-arrow-small margin-top-15-l" href="{{ cta_link }}">{{ cta_text }}</a>
         {% endif %}
+        {% endblock %}
       </div>
     </div>
   </div>

--- a/directory_components/templates/directory_components/cta_box.html
+++ b/directory_components/templates/directory_components/cta_box.html
@@ -1,10 +1,12 @@
 <div id="{{ box_id }}" class="cta-box padding-30 padding-45-m {{ box_class|default:'background-stone-60' }}">
   <div class="grid-row">
     <div class="column-half-m column-full">
+      {% block content %}
       {% if heading %}
         <{{ heading_level|default:'h3' }} class="box-heading {{ heading_class|default:'heading-medium' }}">{{ heading }}</{{ heading_level|default:'h3' }}>
       {% endif %}
       <p class="box-description">{{ description }}</p>
+      {% endblock %}
     </div>
     <div class="column-quarter-xl column-half-m column-full button-container">
       <a id="{{ box_id }}-button" class="button {{ button_class|default:'button-blue' }}" href="{{ button_url }}">{{ button_text }}</a>

--- a/directory_components/templates/directory_components/hero_with_cta.html
+++ b/directory_components/templates/directory_components/hero_with_cta.html
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 <section
   class="hero hero-with-cta"
   data-noscript=""
@@ -13,6 +14,7 @@
   <div class="container">
     <div class="hero-text">
       <h1 class="heading-xlarge {% if subheading %} margin-bottom-0 {% else %} margin-bottom-30 {% endif %} ">{{ heading }}</h1>
+      {% block content %}
       {% if subheading %}
       <h2 class="heading-xlarge margin-top-0 margin-bottom-30">{{ subheading }}</h2>
       {% endif %}
@@ -21,7 +23,8 @@
       {% endif %}
       {% if cta_text and cta_link %}
         <a href="{{ cta_link }}" class="button button-arrow-small button-blue margin-bottom-30">{{ cta_text }}</a>
-      {%  endif %}
+      {% endif %}
+      {% endblock %}
     </div>
   </div>
 </section>

--- a/directory_components/templates/directory_components/hero_with_cta.html
+++ b/directory_components/templates/directory_components/hero_with_cta.html
@@ -1,4 +1,4 @@
-<<<<<<< HEAD
+
 <section
   class="hero hero-with-cta"
   data-noscript=""

--- a/directory_components/templates/directory_components/labelled_card.html
+++ b/directory_components/templates/directory_components/labelled_card.html
@@ -8,12 +8,16 @@
     <div class="card-header">
       <h3 class="title">{% firstof title heading %}</h3>
     </div>
+    {% block image %}
     {% if img_src %}
       {% lazyload %}
         <img class="card-image" src="{{ img_src }}" alt="{{ img_alt }}" {% if card_id %}id="{{ card_id|add:'-image' }}"{% endif %}>
       {% endlazyload %}
     {% endif %}
+    {% endblock %}
     <div class="card-inner {% if img_src %}with-image{% endif %}">
+      {% block content %}
       <p class="description">{{ description }}</p>
+      {% endblock %}
     </div>
 </a>

--- a/directory_components/templates/directory_components/labelled_image_card.html
+++ b/directory_components/templates/directory_components/labelled_image_card.html
@@ -6,6 +6,7 @@
   <div class="card-header">
     <h3 class="title">{{ title }}</h3>
   </div>
+  {% block image %}
   <div class="card-image-container lazyload ls-noscript" data-noscript="">
     <noscript>
       <div
@@ -19,4 +20,5 @@
       </div>
     </noscript>
   </div>
+  {% endblock %}
 </a>

--- a/directory_components/templates/directory_components/message_box.html
+++ b/directory_components/templates/directory_components/message_box.html
@@ -1,6 +1,8 @@
 <div class="message-box padding-15 padding-30-m border-medium {{ box_class|default:'border-teal background-white' }}">
+  {% block content %}
   {% if heading %}
     <{{ heading_level|default:'h3' }} class="box-heading heading-medium {{ heading_class|default:'teal-text' }}">{{ heading }}</{{ heading_level|default:'h3' }}>
   {% endif %}
   <p class="box-description">{{ description }}</p>
+  {% endblock %}
 </div>

--- a/directory_components/templates/directory_components/message_box_with_icon.html
+++ b/directory_components/templates/directory_components/message_box_with_icon.html
@@ -1,9 +1,11 @@
 <div class="message-box-with-icon border-medium border-{{ border_colour|default:'teal' }} {{ box_class|default:'width-full background-white' }}">
   <div class="message-box-icon font-large white-text background-{{ border_colour|default:'teal' }}" aria-hidden="true">{{ icon|default:'✓' }}</div>
   <div class="message-box-content padding-15 padding-30-m">
+    {% block content %}
     {% if heading %}
       <{{ heading_level|default:'h3' }} class="box-heading heading-medium {{ heading_class|default:'teal-text' }}">{{ heading }}</{{ heading_level|default:'h3' }}>
     {% endif %}
     <p class="box-description">{{ description }}</p>
+    {% endblock %}
   </div>
 </div>

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='26.0.0',
+    version='26.1.0',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
allows services to extend the base component templates if they need to modify them slightly without having to rewrite the whole template