### PR TITLE
Fix build on govuk paas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 20.0.1
+[Full Changelog](https://github.com/uktrade/directory-components/pull/225/files)
+### Bug fixes
+- Fixed build on gov uk PaaS
+
+
 ## 20.0.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/224/files)
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,3 @@
+---
+applications:
+  - buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.25

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='20.0.0',
+    version='20.0.1',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
The build process incorrectly inferred this service needs a node environment (it detected package.json). The manifest file pins to a specific build pack