### PR TITLE
Remove old no js stylesheet from base template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 27.1.3
+[Full Changelog](https://github.com/uktrade/directory-components/pull/251/files)
+
+### Bugs fixed
+- Remove reference to old css file in base template
+
 ## 27.1.2
 [Full Changelog](https://github.com/uktrade/directory-components/pull/250/files)
 

--- a/directory_components/templates/directory_components/base.html
+++ b/directory_components/templates/directory_components/base.html
@@ -37,7 +37,6 @@
             .lazyload { visibility: hidden !important; }
         </style>
         <noscript>
-          <link href="{% static 'directory_components/export_elements/stylesheets/elements-components-no-js.min.css' %}" media="all" rel="stylesheet" />
             <style type="text/css">
                 .navigation-toggle { display: block; }
                 .js-disabled-only { display: block; }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='27.1.2',
+    version='27.1.3',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] (if adding HTML) Change is accessible to the standards we subscribe to.
