### PR TITLE
Show non-field errors in forms and deprectate {% render_form form %}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 27.12.0
+[Full Changelog](https://github.com/uktrade/directory-components/pull/267/files)
+
+### Implemented enhancements
+- Show non-field errors in forms
+- Added deprecation warning for `{% render_form form %}`: now can simply do `{{ form }}`.
+
 ## 27.10.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/265/files)
 

--- a/demo/forms.py
+++ b/demo/forms.py
@@ -157,3 +157,7 @@ class DemoFormErrors(PrefixIdMixin, forms.Form):
             (False, 'No'),
         )
     )
+
+    def clean(self, *args, **kwargs):
+        self.add_error(field=None, error=['Some non-field error', 'Some other non-field error'])
+        super().clean(*args, **kwargs)

--- a/demo/templates/demo/form-elements.html
+++ b/demo/templates/demo/form-elements.html
@@ -1,7 +1,7 @@
 {% extends 'demo/base.html' %}
 
 {% load view_instance_code from demo_tags %}
-{% load breadcrumbs render_form from directory_components %}
+{% load breadcrumbs from directory_components %}
 
 {% block css_layout_class %}forms{% endblock %}
 
@@ -13,12 +13,10 @@
 <section class="padding-top-30">
   <div class="container">
     <h1 class="heading-xlarge">Form widgets</h1>
-    <p>A form can be rendered with this template tag:</p>
-<pre><code>{% verbatim %}{% load render_form from directory_components %}
-&lt;form&gt;
-  {% csrf_token %}
-  {% render_form form %}
-&lt;input class="button" type="submit" value="Submit" /&gt;
+    <p>Forms are rendered thusly:</p>
+<pre><code>{% verbatim %}&lt;form&gt;
+  {{ form }}
+  &lt;input class="button" type="submit" value="Submit" /&gt;
 &lt;/form&gt;
 {% endverbatim %}</code></pre>
 
@@ -28,8 +26,7 @@
         <article class="grid-row">
           <div class="column-one-half">
             <form>
-              {% csrf_token %}
-              {% render_form text_form %}
+              {{ text_form }}
               <input class="button margin-top-30" type="submit" value="Submit" />
             </form>
           </div>
@@ -45,8 +42,7 @@
         <article class="grid-row">
           <div class="column-one-half">
             <form>
-              {% csrf_token %}
-              {% render_form form=checkbox_form %}
+              {{ checkbox_form }}
               <div class="form-group">
                 <input class="button" type="submit" value="Submit" />
               </div>
@@ -64,8 +60,7 @@
         <article class="grid-row">
           <div class="column-one-half">
             <form>
-              {% csrf_token %}
-              {% render_form form=multiple_choice_form %}
+              {{ multiple_choice_form }}
               <input class="button" type="submit" value="Submit" />
             </form>
           </div>
@@ -81,8 +76,7 @@
         <article class="grid-row">
           <div class="column-one-half">
             <form>
-              {% csrf_token %}
-              {% render_form form=radio_form %}
+              {{ radio_form }}
               <input class="button" type="submit" value="Submit" />
             </form>
           </div>

--- a/demo/templates/demo/form-errors.html
+++ b/demo/templates/demo/form-errors.html
@@ -1,7 +1,7 @@
 {% extends 'demo/base.html' %}
 
 {% load view_instance_code from demo_tags %}
-{% load breadcrumbs render_form from directory_components %}
+{% load breadcrumbs from directory_components %}
 
 {% block content %}
 <div class="container">
@@ -18,7 +18,7 @@
     </div>
     <form method="post" action="{% url 'form-errors' %}">
       {% csrf_token %}
-      {% render_form form %}
+      {{ form }}
       <input class="button" type="submit" value="Submit" />
     </form>
   </div>

--- a/directory_components/forms/forms.py
+++ b/directory_components/forms/forms.py
@@ -1,13 +1,13 @@
 from directory_constants.choices import COUNTRY_CHOICES
 
 from django import forms
-from django.forms import Select
-from django.utils import translation
 from django.conf import settings
+from django.forms import Select
+from django.template.loader import render_to_string
+from django.utils import translation
 
 from directory_components.forms import fields
 from directory_components import helpers
-
 
 __all__ = [
     'CountryForm',
@@ -28,16 +28,8 @@ class DirectoryComponentsFormMixin:
     use_required_attribute = False
     error_css_class = 'form-group-error'
 
-    def as_p(self):
-        return self._html_output(
-            normal_row=(
-                '<p%(html_class_attr)s>%(label)s %(help_text)s %(field)s</p>'
-            ),
-            error_row='%s',
-            row_ender='</p>',
-            help_text_html=' <span class="form-hint">%s</span>',
-            errors_on_separate_row=True
-        )
+    def __str__(self):
+        return render_to_string('directory_components/form_widgets/form.html', {'form': self})
 
 
 class Form(DirectoryComponentsFormMixin, forms.Form):

--- a/directory_components/templates/directory_components/form_widgets/form.html
+++ b/directory_components/templates/directory_components/form_widgets/form.html
@@ -1,3 +1,10 @@
+{% if form.non_field_errors %}
+  <div class="error-message margin-bottom-30">
+    <div class="{{ form.error_css_class }}">
+      {{ form.non_field_errors }}
+    </div>
+  </div>
+{% endif %}
 {% for field in form %}
   {% include 'directory_components/form_widgets/form_field.html' with field=field %}
 {% endfor %}

--- a/directory_components/templates/directory_components/header_footer/header_country_select.html
+++ b/directory_components/templates/directory_components/header_footer/header_country_select.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load render_form from directory_components %}
 
 {% if features.COUNTRY_SELECTOR_ON and not hide_country_selector  %}
 <section id="country-selector-dialog" class="country-selector-dialog" dir="ltr">

--- a/directory_components/templatetags/directory_components.py
+++ b/directory_components/templatetags/directory_components.py
@@ -1,10 +1,10 @@
 from bs4 import BeautifulSoup
 import re
+import warnings
 
 from django import template
 from django.core.paginator import EmptyPage, Paginator
 from django.templatetags import static
-
 from django.utils.text import slugify
 try:
     # Django < 2.2
@@ -109,6 +109,7 @@ def override_elements_css_class(value, element_and_override):
 
 @register.inclusion_tag('directory_components/form_widgets/form.html')
 def render_form(form):
+    warnings.warn('This feature is deprecated. You can now do {{ form }} in the template to get the same outcome.')
     return {'form': form}
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='27.11.0',
+    version='27.12.0',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,3 +1,5 @@
+from bs4 import BeautifulSoup
+
 from django.utils import translation
 
 from directory_components import forms
@@ -7,3 +9,21 @@ def test_get_language_form_initial_data():
     with translation.override('fr'):
         data = forms.get_language_form_initial_data()
         assert data['lang'] == 'fr'
+
+
+def test_form_render():
+    class Form(forms.Form):
+        field = forms.CharField()
+
+    form = Form()
+
+    expected = """
+        <div class=" form-group" id="id_field-container">
+            <label class=" form-label" for="id_field">Field</label>
+            <input type="text" name="field" class=" form-control" id="id_field">
+        </div>
+    """
+
+    actual = str(form)
+
+    assert BeautifulSoup(actual, 'html.parser') == BeautifulSoup(expected, 'html.parser')

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -194,6 +194,23 @@ def test_render_form():
     assert input_field['id'] == 'id_field'
 
 
+def test_render_form_non_field_errors():
+    form = PaddedTestForm(data={'field': 'value'})
+    form.add_error(field=None, error=['Some error', 'Some other error'])
+    assert form.is_valid() is False
+
+    template = Template(
+        '{% load render_form from directory_components %}'
+        '{% render_form form %}'
+    )
+    context = Context({'form': form})
+
+    html = template.render(context)
+
+    assert 'Some error' in html
+    assert 'Some other error' in html
+
+
 def test_card():
     card_content = {
         'title': 'title',


### PR DESCRIPTION
 - [x] Changelog entry added.
 - [x] Change is accessible to the standards we subscribe to.
 - [x] Add a printscreen to the PR


### demo
![image](https://user-images.githubusercontent.com/5485798/63452858-3e606800-c43f-11e9-9d1f-0ecb45e403e3.png)

![image](https://user-images.githubusercontent.com/5485798/63453116-d8c0ab80-c43f-11e9-83f4-7c70f3dd5927.png)

### in practice

![image](https://user-images.githubusercontent.com/5485798/63453142-e7a75e00-c43f-11e9-98ad-95ee740a4497.png)
