### PR TITLE
Do not render labels and container of hidden form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 30.1.0
+[Full Changelog](https://github.com/uktrade/directory-components/pull/275/files)
+
+### Implemented enhancements
+- Do not render labels and container of hidden form fields
+
 ## 30.0.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/274/files)
 

--- a/directory_components/templates/directory_components/form_widgets/form.html
+++ b/directory_components/templates/directory_components/form_widgets/form.html
@@ -5,6 +5,9 @@
     </div>
   </div>
 {% endif %}
-{% for field in form %}
+{% for field in form.visible_fields %}
   {% include 'directory_components/form_widgets/form_field.html' with field=field %}
+{% endfor %}
+{% for field in form.hidden_fields %}
+    {{ field }}
 {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='30.0.0',
+    version='30.1.0',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup
 
+from django.forms import HiddenInput
 from django.utils import translation
 
 from directory_components import forms
@@ -22,6 +23,26 @@ def test_form_render():
             <label class=" form-label" for="id_field">Field</label>
             <input type="text" name="field" class=" form-control" id="id_field">
         </div>
+    """
+
+    actual = str(form)
+
+    assert BeautifulSoup(actual, 'html.parser') == BeautifulSoup(expected, 'html.parser')
+
+
+def test_form_render_hidden():
+    class Form(forms.Form):
+        field_one = forms.CharField()
+        field_two = forms.CharField(widget=HiddenInput())
+
+    form = Form()
+
+    expected = """
+        <div class=" form-group" id="id_field_one-container">
+            <label class=" form-label" for="id_field_one">Field one</label>
+            <input type="text" name="field_one" class=" form-control" id="id_field_one">
+        </div>
+        <input type="hidden" name="field_two" class=" form-control" id="id_field_two">
     """
 
     actual = str(form)


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] Change is accessible to the standards we subscribe to.
 
this print screen "shows" a hidden field is, well, hidden
![image](https://user-images.githubusercontent.com/5485798/64414975-47cb1080-d08c-11e9-909a-d66851ed9b2b.png)
