### PR TITLE
add field to allow html content to be added inline with the other car…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 35.2.0
+[Full Changelog](https://github.com/uktrade/directory-components/pull/306)
+
+### Implemented enhancements
+- add field to allow html content to be added inline with the other card-inner fields, alternative to html_content
+
 ## 35.1.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/304)
 

--- a/directory_components/templates/directory_components/card.html
+++ b/directory_components/templates/directory_components/card.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load add_export_elements_classes from directory_components %}
 
 <div class="card{% if title and not description and not html_content %} only-title{% endif %}{% if no_padding_card %} no-padding-card{% endif %}{% if transparent_card %} transparent-card{% endif %}"
   {% if card_id %}id="{{ card_id }}"{% endif %}
@@ -29,6 +30,9 @@
         {% endif %}
         {% if description %}
           <p class="description">{{ description }}</p>
+        {% endif %}
+        {% if html_snippet %}
+        {{ html_snippet|add_export_elements_classes }}
         {% endif %}
       {% endif %}
       {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='35.1.0',
+    version='35.2.0',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
…d-inner fields, alternative to html_content

To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] (if adding HTML) Change is accessible to the standards we subscribe to.

