### PR TITLE
Fix missing middle bar of hamburger icon.

### DIFF
--- a/directory_components/export_elements/sass/components/header-footer/_mobile-menu-button.scss
+++ b/directory_components/export_elements/sass/components/header-footer/_mobile-menu-button.scss
@@ -44,7 +44,6 @@
       right: 10px;
       top: 22px;
       transition: background-color .2s ease;
-      background-color: transparent;
 
       &:before {
         @include burger-icon-line;


### PR DESCRIPTION
DON'T ACTUALLY MERGE THIS
====================

I've not
- written the changelog
- compiled the CSS
- actually tested this code


but.. I _think_ its the right change to fix this 
![image](https://user-images.githubusercontent.com/8644502/74763363-9570b980-5277-11ea-8876-59fb417b8f05.png)

sorry for not being more helpful! :)
I've not actually got anything checked out any more!
