### PR TITLE
Upgrade directory-constants to 22.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 38.2.1
+[Full Changelog](https://github.com/uktrade/directory-components/pull/368)
+* KLS-399 - update directory-constants version to 22.0.2
 ## 38.2.0
 [Full Changelog](https://github.com/uktrade/directory-components/pull/367)
 * KLS-115 - update directory-constants version

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='38.2.0',
+    version='38.2.1',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for International Trade',
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'django>=1.11,<4.0.0',
         'beautifulsoup4>=4.6.0,<5.0.0',
-        'directory-constants>=22.0.1,<23.0.0',
+        'directory-constants>=22.0.2,<23.0.0',
         'jsonschema>=3.0.1,<4.0.0',
     ],
     extras_require={


### PR DESCRIPTION
This PR upgrades the minimum requirement for directory-constants to the latest version - 22.0.2.

 - [x] Changelog entry added.
 