### PR TITLE
KLS-1795 - add block for inline feedback inside body tags

### DIFF
--- a/directory_components/templates/directory_components/base.html
+++ b/directory_components/templates/directory_components/base.html
@@ -120,6 +120,9 @@
             </main>
         {% endblock %}
 
+        {% block body_inline_feedback %}
+        {% endblock %}
+
         {% block body_footer %}
             {% if magna_header %}
                 {% include 'directory_components/header_footer/magna_footer.html' %}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_components',
-    version='40.1.1',
+    version='40.2.0',
     url='https://github.com/uktrade/directory-components',
     license='MIT',
     author='Department for Business and Trade',


### PR DESCRIPTION
This PR adds a block to contain inline feedback. The addition is necessary to enable content to be added within body tags that would not be considered part of _main_ content.